### PR TITLE
Updated build.xml and Reame.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,14 @@ To download all the dependency packages, please run the following command
     cd /home/directory/Mr.LDA/
     ant
 
-This should create  `dist/mr.lda-{version}.jar` with all of the proper libraries.
-You may also choose to manually Jar all the .class files and dependency packages to `Mr.LDA.jar`.
+Jar all the .class files anddependency packages to `Mr.LDA.jar`. This can
+either be accomplished manually or by running the following command
+
+    cd /home/directory/Mr.LDA/
+    ant export
+
+The above command should create `bin/Mr.LDA-{version}.jar` with all of the
+proper libraries.
 
 Tokenizing and Indexing
 ----------

--- a/build.xml
+++ b/build.xml
@@ -8,6 +8,7 @@
   <property name="dist.dir" value="dist"/>
   <property name="test.dir" location="test" />
   <property name="javadoc.dir" location="docs/api/" />
+  <property name="bin.dir" location="bin" />
 
   <property name="version" value="0.0.1"/>
 
@@ -40,6 +41,7 @@
     <mkdir dir="${build.dir}" />
     <mkdir dir="${lib.dir}" />
     <mkdir dir="${dist.dir}" />
+    <mkdir dir="${bin.dir}" />
   </target>
 
   <!-- download Ivy from web site so that it can be used even without any special installation -->
@@ -82,7 +84,11 @@
   </target>
 
   <target name="jar" depends="compile" description="generate the distribution">
-      <jar jarfile="${dist.dir}/mrlda-${version}.jar" basedir="${build.dir}">
+      <jar jarfile="${dist.dir}/mrlda-${version}.jar" basedir="${build.dir}" />
+  </target>
+
+  <target name="export" depends="compile" description="generate Jar with all libs">
+      <jar jarfile="${bin.dir}/Mr.LDA-${version}.jar" basedir="${build.dir}">
           <zipgroupfileset dir="${lib.dir}" includes="*.jar"/>
       </jar>
   </target>
@@ -98,6 +104,7 @@
     <delete dir="${lib.dir}" />
     <delete dir="${dist.dir}" />
     <delete dir="${javadoc.dir}" />
+    <delete dir="${bin.dir}" />
   </target>
 
   <target name="test" depends="jar" description="Execute Unit Tests">


### PR DESCRIPTION
## Problem

It is somewhat confusing to create a usable jar
## This Pull

I have added the option for the user to type

`ant export` 

to jar up all the class files and dependencies. I have added this to the Readme.md. 

This puts a `Mr.LDA-{version}.jar` in a new `bin` directory.

I am not entirely happy with `bin` as a directory name, but I couldn't think of a better one...maybe `export`.

Let me know if you want me to change anything.
